### PR TITLE
Do not include basedir into zip, remove version from output directory name

### DIFF
--- a/src/assembly/zip.xml
+++ b/src/assembly/zip.xml
@@ -5,12 +5,13 @@
   <formats>
     <format>zip</format>
   </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}</directory>
-      <outputDirectory>${project.name}-${project.version}</outputDirectory>
+      <outputDirectory>${project.name}</outputDirectory>
       <includes>
-        <include>${project.name}-${project.version}.jar</include>
+        <include>*.jar</include>
       </includes>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
Change zip structure from
pentaho-spark-plugin-VERSION.zip
	|-pentaho-spark-plugin-VERSION
		|-pentaho-spark-plugin-VERSION
			|-pentaho-spark-plugin-VERSION.jar
to
pentaho-spark-plugin-VERSION.zip
	|-pentaho-spark-plugin
		|-pentaho-spark-plugin-VERSION.jar

It will be picked up by kettle's assembly: https://github.com/pentaho/pentaho-kettle/pull/1230
@smaring @lgrill-pentaho 