### PR TITLE
[PDI-14541] All plugins bundled with pdi should have version.xml--fix…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,23 +67,7 @@
   </dependencies>
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>package-assembly</id>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-            <configuration>
-              <descriptor>src/assembly/zip.xml</descriptor>
-              <appendAssemblyId>false</appendAssemblyId>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
+	  <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <version>2.7</version>
         <executions>
@@ -124,6 +108,22 @@
           <token>@TRUNK@</token>
           <value>${project.version}</value>
         </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>package-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptor>src/assembly/zip.xml</descriptor>
+              <appendAssemblyId>false</appendAssemblyId>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/assembly/zip.xml
+++ b/src/assembly/zip.xml
@@ -13,6 +13,7 @@
       <outputDirectory>${project.name}</outputDirectory>
       <includes>
         <include>*.jar</include>
+	<include>version.xml</include>
       </includes>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
… to include in zip file. 

From my last fix, the version.xml was being generated, but not included in the plugin zip file. This fix corrected that.

@bmorrise 
@mdamour1976 